### PR TITLE
Messaging reset: reposition hero, real About page, Résumé page

### DIFF
--- a/_includes/navigation/navigation.liquid
+++ b/_includes/navigation/navigation.liquid
@@ -20,6 +20,8 @@
     {% for service in links_by_order %}
       {% include navigation/navigation-link.liquid %}
     {% endfor %}
+    <a href="/about/" {% if page.url == "/about/" %}class="current"{% endif %}>About</a>
+    <a href="/resume/" {% if page.url == "/resume/" %}class="current"{% endif %}>Résumé</a>
   </nav>
   {% include shared/cta-button.liquid %}
 </header>

--- a/_services/branding.md
+++ b/_services/branding.md
@@ -5,11 +5,11 @@ name: branding
 permalink: /branding
 title: Branding Design
 description: >-
-  With over ten years of freelance and agency experience, you can be assured
-  that you will receive a logo that will stand out without going out of style. I
-  deliver high-quality work that will look great both in print and on screen.
+  Brand identity built alongside the product work: logo systems, typography, and
+  visual guidelines. Early-stage clients leave with a coherent presence that
+  holds up in print and on screen.
 frame_url: 'https://my.spline.design/clonertubescopycopy-umFrCpQsnuFKZyK8XLmO3XGm/'
-services-tagline: Connent with your audience in print and online
+services-tagline: Connect with your audience in print and online
 tags:
   - name: Visual Identity
   - name: Brand Guide

--- a/_services/product-design.md
+++ b/_services/product-design.md
@@ -6,9 +6,9 @@ name: product design
 tags:
   - name: UI/UX
   - name: Web Development
-title: Digital Product Design
-description: Over the past ten years, I've helped to combine my clients' vision of the future with the perspectives of their users to create  stunning, tailored experiences that are accessible to everyone on the web
+title: Digital products, story-mapped and built in the browser
+description: 14 years designing digital products inside small, mighty teams, from the user's story up. Every engagement starts with story mapping and stakeholder interviews, then moves into browser prototyping alongside the build team, now paired with AI agents I author that compress weeks of discovery into days.
 frame_url: https://my.spline.design/clonercubesimplecopy-bb630613937366454aab26e86c0a12b7/
-services-tagline: I make growing your product easy at every stage
+services-tagline: How I work with a build team, from discovery through shipped front-end code
 active: true
 ---

--- a/about.md
+++ b/about.md
@@ -1,17 +1,37 @@
 ---
-layout: page
+layout: shared
 title: About
 permalink: /about/
 ---
 
-This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](https://jekyllrb.com/)
+<section class="section">
+  <div class="container">
+    <header class="u-mb-500">
+      <div class="tag-container u-mb-100">
+        <div class="tag">Product Designer</div>
+      </div>
+      <h1>About</h1>
+    </header>
 
-You can find the source code for Minima at GitHub:
-[jekyll][jekyll-organization] /
-[minima](https://github.com/jekyll/minima)
+    <div class="card">
+      <div class="card__body">
+        <p class="u-mb-300">I have spent 14 years designing digital products inside small, mighty teams, working from the user's story up. Every engagement starts the same way, with user story mapping and stakeholder interviews to find the real demand, and then the work moves into the browser, where I prototype alongside the build team instead of handing comps over a wall. Lately I pair that practice with AI agents I author, which compress weeks of discovery into days while keeping the methodology story-map-first.</p>
 
-You can find the source code for Jekyll at GitHub:
-[jekyll][jekyll-organization] /
-[jekyll](https://github.com/jekyll/jekyll)
+        <p class="u-mb-300">I learned the approach across a decade at Launch Scout, a custom-software consultancy where I designed B2B SaaS, enterprise, and 0-to-1 products in finance, pharma, manufacturing, aviation, and Web3. Story mapping anchored every engagement, and the "Design Sandwich" kept UX, development, and UI iterating together rather than separately. That decade is where I learned to design in code, shipping the production front ends that reached real users.</p>
 
-[jekyll-organization]: https://github.com/jekyll
+        <p class="u-mb-300">I refined the practice at Configure, an AI-assisted construction-procurement marketplace, where I was the design founder. I owned design across the buyer platform, the Atlas storefront, the seller pricing tools, and Configure Approvals, and I shipped that UI as production Blazor and Razor components alongside the .NET team with no Figma-to-production handoff. Today I carry the same approach into Ryan Arthur Digital, partnering with founders, product teams, and agencies to take products from discovery to launch.</p>
+
+        <p class="u-mb-300">The proof is in the work. At Launch Scout I led design on the construction marketplace that later became Configure, from design sprint through launch, and it secured more than $1.5M in seed funding in its first year and drew buy-in from Autodesk. I designed PRESTO, a work-order system that replaced paper across 3 facilities in 3 states with no parallel run, which the COO called "functional software we could test." I won a NASA Tournament Lab challenge for a ground control station that let one operator monitor and control multiple autonomous aircraft. And the AI discovery workflow I build now, pairing Claude agent personas with code-based prototyping in Next.js, is what makes weeks of story-mapping fit into days.</p>
+
+        <p>If any of that sounds like the kind of team you are building, I would like to hear about it.</p>
+      </div>
+    </div>
+
+    <div class="u-mb-400"></div>
+
+    <a href="mailto:ryan@ryanarthurdigital.com?subject=Work with me!&body=👋 Tell me a little bit about your project." class="button button--secondary">
+      <span class="button__icon button__icon--wave">👋</span>
+      Get in touch
+    </a>
+  </div>
+</section>

--- a/resume.md
+++ b/resume.md
@@ -1,0 +1,151 @@
+---
+layout: shared
+title: Résumé
+permalink: /resume/
+---
+
+<section class="section">
+  <div class="container">
+    <div class="card">
+      <header class="card__header">
+        <div class="tag-container u-mb-100">
+          <div class="tag">Product Designer</div>
+        </div>
+        <h1>Ryan Arthur</h1>
+      </header>
+      <div class="card__body">
+        <p class="u-mb-300">14 years designing digital products inside small, mighty teams, from the user's story up. Every engagement starts with user story mapping and stakeholder interviews, then moves into browser prototyping alongside the build team. Lately I pair that practice with AI agents I author, which compresses weeks of discovery into days. I learned the approach across a decade at Launch Scout, refined it at Configure, and carry it into every engagement at Ryan Arthur Digital.</p>
+        <a href="/assets/Ryan-Arthur-Product-Designer-Resume.pdf" class="button">
+          <span class="button__icon">📄</span>
+          Download PDF
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <h2 class="u-mb-400">Experience</h2>
+
+    <div class="card u-mb-300">
+      <header class="card__header">
+        <h3>Product Designer and Founder, Ryan Arthur Digital</h3>
+        <p>2022 to Present</p>
+      </header>
+      <div class="card__body">
+        <ul class="u-mb-300">
+          <li>Partner with founders, product teams, and agencies to take products from discovery to launch, owning research, UX, UI, prototyping, and front-end code.</li>
+          <li>Redesigned time-entry, review, and admin workflows for AddnAide, a HIPAA-adjacent home-healthcare platform, shipping every mockup as a full-fidelity Phoenix LiveView prototype, mobile-first for aides in the field, with EVV and compliance flows built so the compliant path is the easy path.</li>
+          <li>Built an AI-assisted discovery workflow that pairs Claude agent personas I author with code-based prototyping in Next.js, grounded in user story mapping and jobs-to-be-done, compressing weeks of story-mapping into days.</li>
+          <li>Ship production HTML, CSS, and JavaScript to web-component and accessibility standards, and build design systems in Figma and code that keep client teams fast after handoff.</li>
+          <li>Won a NASA Tournament Lab challenge for a ground control station interface that let one operator monitor and control multiple autonomous aircraft.</li>
+        </ul>
+        <div class="tag-container">
+          <div class="tag">Phoenix LiveView</div>
+          <div class="tag">Next.js</div>
+          <div class="tag">AI Agents</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card u-mb-300">
+      <header class="card__header">
+        <h3>UX Engineer, Configure, Inc.</h3>
+        <p>2023 to 2025</p>
+      </header>
+      <div class="card__body">
+        <ul class="u-mb-300">
+          <li>Sole designer for Configure 2.0, an AI-assisted construction-procurement marketplace, owning design and shipping production UI across the buyer platform (DemandPortal, Bid Day), the Atlas storefront and discovery platform, the seller pricing tools, and Configure Approvals.</li>
+          <li>Designed and shipped Bid Day end to end, from project setup and Bill-of-Design management to quote import with PDF-to-text conversion, multi-vendor comparison, and exportable selections, built as Blazor and Razor components.</li>
+          <li>Designed the multi-sided Atlas marketplace, including manufacturer and supplier storefronts, search, professional networking, an activity feed, and a SignalR-driven notifications layer with embedded CometChat.</li>
+          <li>Shipped Configure Approvals, a submittals workflow built on code-shareable Clipboards where stakeholders share by short code, suggest swaps, and send to order, mobile-first for client review.</li>
+          <li>Designed Configure Assistant, the platform's AI product-recommendation chat, partnering with the AI team on a knowledge-graph backend built on ontoGPT and OpenAI function-calling.</li>
+          <li>Stood up the design system in code, an SCSS token foundation and a domain-specific Blazor component library, written in Razor and Blazor alongside the .NET team with no Figma-to-production handoff.</li>
+        </ul>
+        <div class="tag-container">
+          <div class="tag">Blazor / Razor</div>
+          <div class="tag">SCSS</div>
+          <div class="tag">.NET</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <header class="card__header">
+        <h3>UX Designer, Launch Scout</h3>
+        <p>2012 to 2022</p>
+      </header>
+      <div class="card__body">
+        <ul class="u-mb-300">
+          <li>Spent 10 years at a custom-software consultancy designing B2B SaaS, enterprise, and 0-to-1 products across finance, pharma, manufacturing, AEC, aviation, and Web3, from discovery through shipped front-end code.</li>
+          <li>Practiced Launch Scout's discovery-led process, where user story mapping anchored every engagement and the "Design Sandwich" kept UX, development, and UI iterating together inside small, mighty teams. I have carried it into every role since.</li>
+          <li>Led design on the construction-procurement marketplace for KLH Engineers, from design sprint through launch. It secured more than $1.5M in seed funding in year one and drew buy-in from Autodesk.</li>
+          <li>Designed PRESTO for E-Beam Services, a work-order system that replaced paper across 3 facilities in 3 states with no parallel run. The COO called it "functional software we could test."</li>
+          <li>Built production front ends for an open-source blockchain explorer (POA Network and BlockScout) and a real-time pharmacy-pricing platform for Omnicare, a CVS Health company.</li>
+        </ul>
+        <div class="tag-container">
+          <div class="tag">User Story Mapping</div>
+          <div class="tag">Design Sandwich</div>
+          <div class="tag">Front-End Code</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <h2 class="u-mb-400">Education</h2>
+    <div class="card">
+      <div class="card__body">
+        <h3>BSA Visual Communication</h3>
+        <p>University of Cincinnati, DAAP. 2008 to 2013.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container">
+    <h2 class="u-mb-400">Skills</h2>
+
+    <h3 class="u-mb-100">Design</h3>
+    <div class="tag-container u-mb-300">
+      <div class="tag">Figma</div>
+      <div class="tag">UX Design</div>
+      <div class="tag">UI Design</div>
+      <div class="tag">Design Sprints</div>
+      <div class="tag">User Story Mapping</div>
+      <div class="tag">Stakeholder Interviews</div>
+      <div class="tag">Information Architecture</div>
+      <div class="tag">Wireframing</div>
+      <div class="tag">Interaction Design</div>
+      <div class="tag">Design Systems</div>
+      <div class="tag">Design Tokens</div>
+      <div class="tag">User Testing</div>
+      <div class="tag">Mobile-First Design</div>
+    </div>
+
+    <h3 class="u-mb-100">Code</h3>
+    <div class="tag-container u-mb-300">
+      <div class="tag">HTML</div>
+      <div class="tag">CSS / SCSS</div>
+      <div class="tag">JavaScript / TypeScript</div>
+      <div class="tag">Phoenix LiveView</div>
+      <div class="tag">Blazor / Razor</div>
+      <div class="tag">Next.js</div>
+      <div class="tag">Web Components</div>
+      <div class="tag">Web Accessibility</div>
+      <div class="tag">Git</div>
+      <div class="tag">Agile</div>
+    </div>
+
+    <h3 class="u-mb-100">AI</h3>
+    <div class="tag-container">
+      <div class="tag">Jobs-to-Be-Done</div>
+      <div class="tag">Claude Code</div>
+      <div class="tag">AI Agent Authoring</div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
Part of the content & messaging refresh, stacked onto `release/content-refresh`. Not live until the release branch merges to `gh-pages`.

## What this does
Re-aims the site from "freelance services for hire" toward a senior product designer demonstrating method and impact. Copy follows the `copywriter.md` voice (warm, factual, confident; no em dashes, no hedges, no filler).

- **Homepage hero** (`_services/product-design.md`) rewritten to lead with method and seniority:
  - title: *Digital products, story-mapped and built in the browser*
  - description: the 14-years / story-mapping / browser-prototyping / AI-discovery throughline
  - services tagline reframed around working with a build team
- **Real About page** (`about.md`) replaces the default-Jekyll boilerplate, using `layout: shared` so it matches the site chrome. Tells the Launch Scout → Configure → Ryan Arthur Digital arc with concrete proof points ($1.5M seed + Autodesk, PRESTO, NASA win, the AI discovery workflow).
- **Styled Résumé page** (`/resume/`) with experience, education, and grouped skills, plus a **Download PDF** button.
- **Nav** gains **About** and **Résumé** links.
- Branding service page: fix `Connent` → `Connect`, tighten the description.

## Action needed from you
The Download PDF button links to `/assets/Ryan-Arthur-Product-Designer-Resume.pdf`. **Commit that PDF to `assets/`** (any branch in this release) so the link resolves; until then it 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)