### PR TITLE
Restructure case studies: Problem → Role → Process → Outcome

### DIFF
--- a/_case-studies/Matador-Logo.md
+++ b/_case-studies/Matador-Logo.md
@@ -4,7 +4,17 @@ description: >-
   A logo for a fictional athletic gear company that embodies the essence of
   pushing performance limits with sleek, high-quality products, encapsulated in
   the ethos: Stand strong. Be bold. Command attention.
-cover_image: /assets/images//case-studies/thumbnails//matador.webp
+problem: >-
+  Matador is a fictional athletic gear company built on a single ethos, stand
+  strong, be bold, command attention. It needed a mark that read as
+  high-performance without leaning on the visual cliches of the category.
+role: >-
+  I designed the logo and wordmark, building the stylized bull horns and nose
+  ring into the lettering and setting the navy, red, and white palette.
+outcome: >-
+  The result is a minimalist, geometric mark with the bull horns and nose ring
+  worked into the wordmark, carried by a navy, red, and white palette.
+cover_image: /assets/images/case-studies/thumbnails/matador.webp
 illustration: /assets/images/case-studies/illustrations/matador-logo-illustration.svg
 color: red
 category: branding
@@ -35,6 +45,6 @@ solutions:
       the brand in dependability. Vibrant red reflects passion, energy, and
       boldness—the daring spirit of a challenger unafraid of risks. Crisp white
       provides balance, representing clarity, honesty, and transparency.
-    media: /assets/images//case-studies//matador.webp
+    media: /assets/images/case-studies/matador.webp
 ---
 

--- a/_case-studies/Tech-Agency-Brand-Guideline.md
+++ b/_case-studies/Tech-Agency-Brand-Guideline.md
@@ -5,10 +5,22 @@ description: >-
   on custom software solutions. The core of the brand identity is a logo that
   blends a spaceship and an eye. Although it wasn't ultimately selected, it was
   a strong contender for the final design.
+problem: >-
+  Launch Scout, a tech agency building custom software, needed a brand identity
+  that read as both credible and creative. The work called for a logo system,
+  type, color, and the guidelines to keep it consistent across digital and
+  print.
+role: >-
+  I designed the brand concept end to end, from the logomark and the logotype
+  set in a modified Gilroy ExtraBold to the alignment and layout variations, the
+  color system, and the typographic hierarchy and applications.
+outcome: >-
+  The concept was a strong contender for the final brand but wasn't ultimately
+  selected.
 cover_image: >-
-  /assets/images//case-studies/thumbnails//tech-agency-brand-guidelines-thumbnial.webp
+  /assets/images/case-studies/thumbnails/tech-agency-brand-guidelines-thumbnial.webp
 illustration: >-
-  /assets/images//case-studies/illustrations//tech-agency-brand-guidelines-thumbnial.webp
+  /assets/images/case-studies/illustrations/tech-agency-brand-guidelines-thumbnial.webp
 color: purple
 category: branding
 services:
@@ -37,7 +49,7 @@ solutions:
       brand asset. The accompanying logotype, a modified version of Gilroy
       ExtraBold, was selected for its clean, geometric forms that project a
       sense of modernity and stability.
-    media: /assets/images//case-studies//launch-scout-logo.png
+    media: /assets/images/case-studies/launch-scout-logo.png
   - title: Alignment
     description: >-
       I meticulously defined the alignment and whitespace to ensure the logo
@@ -45,7 +57,7 @@ solutions:
       of horizontal, vertical, and knockout variations demonstrates a
       forward-thinking approach, ensuring the brand is versatile and adaptable
       to any platform or medium.
-    media: /assets/images//case-studies//launch-scout-alignment.png
+    media: /assets/images/case-studies/launch-scout-alignment.png
   - title: Layout Variations
     description: >-
       I developed a series of horizontal and vertical logo layouts to ensure
@@ -54,7 +66,7 @@ solutions:
       on social media, or a tall banner ad. This isn't just a matter of
       aesthetics; it's a strategic decision that guarantees the brand's
       visibility and impact across all platforms, from digital to print.
-    media: /assets/images//case-studies//launch-scout-layout.png
+    media: /assets/images/case-studies/launch-scout-layout.png
   - title: Color Palette
     description: >-
       The color palette was strategically chosen to reinforce Launch Scout's
@@ -65,7 +77,7 @@ solutions:
       secondary palette of vibrant hues like yellow, fuchsia, and coral. These
       colors are used as accents to highlight key information and create visual
       interest without compromising the brand's professional tone. 
-    media: /assets/images//case-studies//launch-scout-colors.png
+    media: /assets/images/case-studies/launch-scout-colors.png
   - title: Color Combinations
     description: >-
       The palette is designed to be a strategic balance of opposing forces. The
@@ -76,7 +88,7 @@ solutions:
       sophisticated and approachable brand, demonstrating that Launch Scout is
       both an authoritative leader and a creative, dynamic partner in the custom
       software space.
-    media: /assets/images//case-studies//launch-scout-combinations.png
+    media: /assets/images/case-studies/launch-scout-combinations.png
   - title: Typography
     description: >-
       The typographic system was designed to create a clear visual hierarchy and
@@ -89,7 +101,7 @@ solutions:
       these fonts ensures that the brand's messaging is not only visually
       consistent but also effortlessly legible, communicating expertise and
       attention to detail at every level.
-    media: /assets/images//case-studies//launch-scout-typography.png
+    media: /assets/images/case-studies/launch-scout-typography.png
   - title: Applications
     description: >-
       The application mockups were created to illustrate the brand's cohesive
@@ -101,6 +113,6 @@ solutions:
       across various touchpoints. This level of detail in brand application
       reassures clients that the visual solution is not just an idea but a
       practical and well-thought-out system built for long-term success.
-    media: /assets/images//case-studies//launch-scout-applications.png
+    media: /assets/images/case-studies/launch-scout-applications.png
 ---
 

--- a/_case-studies/banking-compliance-tracker.md
+++ b/_case-studies/banking-compliance-tracker.md
@@ -3,6 +3,18 @@ title: Banking Compliance Tracker
 description: >-
   Helping a financial service company provide even more insight to their
   customers by re-imagining how data is visualized
+problem: >-
+  Mitratech's RegTech platform automates risk, compliance, vendor, and
+  performance management for the financial industry, but executives struggled to
+  read across that data. Key performance indicators, projects, and timelines
+  lived in separate views, so the strategic picture stayed buried.
+role: >-
+  I led design through the sprint, owning the user story map, UI flow outline,
+  and the dashboard and prototype work in Adobe XD.
+outcome: >-
+  The new dashboards put KPIs, project timelines, and Gantt and list views in
+  one place, so executives could read progress across projects and spot what
+  needed attention at a glance.
 cover_image: >-
   /assets/images/case-studies/thumbnails/banking-compliance-tracker-thumbnail.png
 category: product design
@@ -57,7 +69,7 @@ solutions:
     media: /assets/images/case-studies/compliance-tracker-strategic-dashboard.png
   - title: KPI Category Overview
     description: >-
-      Each KPI category can have serval projects all going on simultaneously.
+      Each KPI category can have several projects all going on simultaneously.
       This overview page shows executives how their projects fit together on a
       timeline. This allows for strategic insights that otherwise would never be
       possible. 

--- a/_case-studies/blockchain-explorer.md
+++ b/_case-studies/blockchain-explorer.md
@@ -3,6 +3,18 @@ title: Blockchain Explorer
 description: >-
   A tool for inspecting and analyzing EVM based blockchains on Ethereum Networks
   in real time.
+problem: >-
+  EVM and Ethereum networks generate blocks and transactions constantly, but
+  developers and users had no open-source way to inspect that activity in a
+  readable interface. They needed to see blocks, transactions, addresses, and
+  token holdings as they happened.
+role: >-
+  I designed and built the front end of the open-source blockchain explorer,
+  shipping the production interface in HTML with EEx and Sass and a custom
+  component library.
+outcome: >-
+  The explorer shipped over about 6 months with real-time block and transaction
+  views, address pages, and token holdings, built on a custom component library.
 cover_image: /assets/images/case-studies/thumbnails/blockchain-explorer-thumbnail.png
 category: product design
 services:
@@ -41,7 +53,7 @@ solutions:
     description: >-
       Every address on the blockchain has a dedicated page where all address
       activity is recorded. Easily browse an address's content and review a
-      complete history of transactions. I used color queues to visually
+      complete history of transactions. I used color cues to visually
       distinguish transaction types and provided links for users to drill into
       additional content. 
     media: /assets/images/case-studies/blockchain-address-transactions.png

--- a/_case-studies/city-transit-app.md
+++ b/_case-studies/city-transit-app.md
@@ -3,6 +3,16 @@ title: City Transit App
 description: >-
   A dashboard and companion app that was submitted as a bid for a grant to help
   people move around the city of Cincinnati
+problem: >-
+  Getting around Cincinnati means piecing together routes from separate transit
+  options with no single view of what's available. The grant called for a way to
+  use open data to make the city easier to move through.
+role: >-
+  I designed the dashboard and companion app concept, owning the UX and UI for
+  the mobile-first screens.
+outcome: >-
+  The dashboard and companion app went out as a bid for the city grant, using
+  open data sources to suggest routes and surface nearby transit options.
 cover_image: /assets/images/case-studies/thumbnails/city-transit-app-thumbnail.png
 category: product design
 services:

--- a/_case-studies/construction-marketplace.md
+++ b/_case-studies/construction-marketplace.md
@@ -1,8 +1,20 @@
 ---
 title: Construction Marketplace
 description: >-
-  Transition from the design phase to procurement seemlessly by applying 21st
+  Transition from the design phase to procurement seamlessly by applying 21st
   century connectivity to an old-school process
+problem: >-
+  Building designers and contractors specify and buy products through email,
+  phone calls, and PDFs scattered across vendors. Comparing quotes from multiple
+  suppliers meant reconciling files by hand, and the work that moves a project
+  from design to purchase had no shared place to live.
+role: >-
+  I led design on the construction-procurement marketplace from the design
+  sprint through launch, owning research, UX, UI, and the production front end
+  in HTML, CSS, and Razor alongside the .NET and Blazor build team.
+outcome: >-
+  The product secured more than $1.5M in seed funding in its first year and drew
+  industry buy-in from Autodesk.
 cover_image: /assets/images/case-studies/thumbnails/construction-marketplace-thumbnail.png
 category: product design
 services:

--- a/_case-studies/francie-thurman.md
+++ b/_case-studies/francie-thurman.md
@@ -2,6 +2,15 @@
 title: Francie Thurman Realty
 description: >-
   This branding project focused on creating a refined logo and wordmark for a local realtor.
+problem: >-
+  Francie Thurman, a local realtor, needed an identity that signaled luxury
+  listings while still feeling approachable to the clients she works with.
+role: >-
+  I designed the logo, wordmark, and supporting collateral, including business
+  cards and brochures.
+outcome: >-
+  The identity pairs a symbol drawn from the ease of home living with a refined
+  wordmark, balancing elegance with an approachable, trustworthy feel.
 cover_image: /assets/images/case-studies/thumbnails/francie-thurman-realty-thumbnail.png
 category: branding
 services:

--- a/_case-studies/ground-control-station.md
+++ b/_case-studies/ground-control-station.md
@@ -3,6 +3,18 @@ title: Ground Control Station
 description: >-
   The goal of this NASA sponsored challenge was to design an effective interface
   for simultaneously managing multiple autonomous vehicles.
+problem: >-
+  NASA is researching future aviation operations where a single pilot controls
+  multiple aircraft remotely at once. The challenge was to design a ground
+  control station that gives one operator a clear picture of many vehicles
+  without overwhelming them.
+role: >-
+  I designed the interface end to end for this competition entry, owning the
+  research, UX, and UI, including the icon and color system that signals each
+  vehicle's status at a glance.
+outcome: >-
+  The design won the NASA-sponsored challenge. It let one operator monitor and
+  control multiple autonomous aircraft at once.
 cover_image: /assets/images/case-studies/thumbnails/ground-control-station-thumbnail.png
 category: product design
 services:
@@ -52,7 +64,7 @@ solutions:
       The mission timeline displays a representation of a vehicle's progress
       through a planned mission. It also serves a dual purpose of graphically
       showing the vehicle altitude that can't be seen on the top-down map. The
-      user can scrub through the timeline to see recorded or estimated spacial
+      user can scrub through the timeline to see recorded or estimated spatial
       information to plan or review a mission.
     media: /assets/images/case-studies/ground-control-station-checklist.png
   - title: network

--- a/_case-studies/sales-analysis-tool.md
+++ b/_case-studies/sales-analysis-tool.md
@@ -1,8 +1,19 @@
 ---
 title: Sales Analysis Tool
 description: >-
-  Seeing data update in real time empowered sales assocciates to to engineer the
+  Seeing data update in real time empowered sales associates to engineer the
   best deals possible.
+problem: >-
+  Institutional pharmacy pricing at Omnicare moved through spreadsheets emailed
+  around the department. Files went stale, edits were hard to trace, and sales
+  associates had no shared place to compare pricing or see the effect of a
+  change in real time.
+role: >-
+  I designed the sales analysis tool and shipped the production front end in
+  HTML with Slim and Sass, partnering with engineering across the engagement.
+outcome: >-
+  The emailed spreadsheets gave way to a shared, audited platform where every
+  change is backed up and traceable. The engagement ran about 9 months.
 cover_image: /assets/images/case-studies/thumbnails/sales-analysis-tool-thumbnail.png
 category: product design
 services:

--- a/_case-studies/work-order-management.md
+++ b/_case-studies/work-order-management.md
@@ -3,6 +3,21 @@ title: Work Order Management
 description: >-
   A custom process requires a custom solution. I helped to turn a scattered
   paper trail into an easy to understand application.
+problem: >-
+  E-Beam Services ran work orders on paper across 3 facilities in 3 states.
+  Products in a single job split across multiple work orders and paper
+  workbooks, so managers had no reliable way to track progress, calibrate
+  machines, or troubleshoot bottlenecks across plants.
+role: >-
+  I led design on PRESTO and shipped the production front end in HTML with ERB
+  and HBS and Sass, working alongside the build team on the Ruby on Rails and
+  Ember stack.
+outcome: >-
+  PRESTO replaced paper across all 3 facilities with no parallel run and minimal
+  training. The COO called it functional software the team could test.
+quote: >-
+  Functional software we could test.
+quote_attribution: COO, E-Beam Services
 cover_image: /assets/images/case-studies/thumbnails/work-order-management-thumbnail.png
 category: product design
 services:
@@ -69,7 +84,7 @@ solutions:
   - title: production queue
     description: >-
       What was spread out across numerous paper workbooks is now consolidated
-      into one easy to, easy to access queue. The new production queue provides
+      into one queue that's easy to access. The new production queue provides
       accuracy and reliability for all machines running in multiple plants.
     media: /assets/images/case-studies/work-order-production-queue.png
   - title: work order products

--- a/_includes/case-study/outcome-section.liquid
+++ b/_includes/case-study/outcome-section.liquid
@@ -1,0 +1,8 @@
+{% if page.outcome %}
+  <section class="section">
+    <div class="container">
+      <h2 class="u-mb-300">Outcome</h2>
+      <p>{{ page.outcome }}</p>
+    </div>
+  </section>
+{% endif %}

--- a/_includes/case-study/overview-section.liquid
+++ b/_includes/case-study/overview-section.liquid
@@ -1,0 +1,8 @@
+{% if page.problem %}
+  <section class="section">
+    <div class="container">
+      <h2 class="u-mb-300">The problem</h2>
+      <p>{{ page.problem }}</p>
+    </div>
+  </section>
+{% endif %}

--- a/_includes/case-study/real-testimonial-section.liquid
+++ b/_includes/case-study/real-testimonial-section.liquid
@@ -1,0 +1,13 @@
+{% if page.quote %}
+  <section class="section section--accent">
+    <div class="container">
+      <h2 class="u-mb-300">In their words</h2>
+      <figure class="testimonial-card__testimonial">
+        <blockquote class="testimonial-card__quote">{{ page.quote }}</blockquote>
+        {% if page.quote_attribution %}
+          <figcaption class="testimonial-card__attribution">{{ page.quote_attribution }}</figcaption>
+        {% endif %}
+      </figure>
+    </div>
+  </section>
+{% endif %}

--- a/_includes/case-study/role-section.liquid
+++ b/_includes/case-study/role-section.liquid
@@ -1,0 +1,8 @@
+{% if page.role %}
+  <section class="section section--accent">
+    <div class="container">
+      <h2 class="u-mb-300">My role</h2>
+      <p>{{ page.role }}</p>
+    </div>
+  </section>
+{% endif %}

--- a/_includes/case-study/testimonial-section.liquid
+++ b/_includes/case-study/testimonial-section.liquid
@@ -1,5 +1,8 @@
-<section class="section">
-  <div class="container">
-    {% include case-study/testimonial-card.liquid %}
-  </div>
-</section>
+{% if page.testimonial %}
+  <section class="section">
+    <div class="container">
+      <h2 class="u-mb-300">About the client</h2>
+      {% include case-study/testimonial-card.liquid %}
+    </div>
+  </section>
+{% endif %}

--- a/_layouts/case-study.md
+++ b/_layouts/case-study.md
@@ -12,13 +12,29 @@ layout: shared
 
 {% include case-study/services-section.liquid %}
 
-<!-- Testimonial -->
+<!-- The Problem -->
 
-{% include case-study/testimonial-section.liquid %}
+{% include case-study/overview-section.liquid %}
+
+<!-- My Role -->
+
+{% include case-study/role-section.liquid %}
 
 <!-- Solution -->
 
 {% include case-study/solution-section.liquid %}
+
+<!-- Outcome -->
+
+{% include case-study/outcome-section.liquid %}
+
+<!-- Real Testimonial -->
+
+{% include case-study/real-testimonial-section.liquid %}
+
+<!-- About the Client -->
+
+{% include case-study/testimonial-section.liquid %}
 
 <!-- See More -->
 


### PR DESCRIPTION
Part of the content & messaging refresh, stacked onto `release/content-refresh`. Not live until the release branch merges to `gh-pages`.

## What this does
Turns the case studies from feature tours (a list of screens) into real case studies a hiring manager can evaluate.

- **New narrative arc** on all nine studies via front matter (`problem`, `role`, `outcome`) and new includes, rendered in order: hero → at-a-glance → **The problem** → **My role** → Solution (process walk-through) → **Outcome** → testimonial → keep reading → CTA.
- **Real outcomes and metrics** added from the resume: $1.5M seed + Autodesk buy-in (construction marketplace), zero parallel-run across 3 facilities (PRESTO), NASA Tournament Lab win, 9-month Omnicare engagement, etc.
- **"We" vs "I" disambiguated** — each study states what Ryan owned (sole/lead designer, shipped the front-end code) without overclaiming team work.
- **Mislabeled "testimonials" fixed**: the client mission statements are now honestly labeled **"About the client"**, and a **real testimonial** (E-Beam's COO: "Functional software we could test.") is added where one exists.
- **Typos fixed** (seemlessly, assocciates, serval, color queues, spacial, etc.) and **double-slash image paths** collapsed.

## Notes
- No invented claims: studies without a metric (Mitratech, city transit, branding concepts) state the real factual outcome with no numbers.
- Does not touch the solution screenshot includes (owned by the hygiene PR's alt-text work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)