### PR TITLE
Add flagship case studies: AddnAide, Configure 2.0, AI-Assisted Discovery

### DIFF
--- a/_case-studies/addnaide.md
+++ b/_case-studies/addnaide.md
@@ -1,0 +1,118 @@
+---
+title: AddnAide
+description: >-
+  A home-healthcare workforce platform where time entry, review, and admin work
+  across five roles, with every screen shipped as a working browser prototype.
+problem: >-
+  Home-healthcare operations span five roles, aides, care managers, employers,
+  clients, and admins, and the work of logging time, reviewing it, and running
+  the agency has to satisfy Electronic Visit Verification and program-compliance
+  rules at every step. The time-entry, review, and admin workflows were due for
+  a redesign that handled those rules without slowing the people doing the work.
+role: >-
+  I was the sole designer. I owned research, UX, and UI, authored the design
+  system, and shipped every mockup as a full-fidelity Phoenix LiveView prototype
+  in the browser, so each screen was real and clickable rather than a static
+  comp.
+outcome: >-
+  Every screen shipped as a working LiveView prototype. The design system landed
+  as a 17-section style guide covering tokens, components, accessibility, dark
+  mode, and architecture decision records. EVV and program-compliance flows were
+  built so the compliant path is the easy path, and the whole experience is
+  mobile-first for aides working in the field.
+cover_image: /assets/images/case-studies/placeholder.svg
+category: product design
+services:
+  - name: Research & UX
+    timeline: 4 months
+    tags:
+      - name: User Story Mapping
+      - name: Stakeholder Interviews
+      - name: Information Architecture
+      - name: Mobile-First Design
+  - name: UI Design
+    timeline: 4 months
+    tags:
+      - name: Design System
+      - name: Design Tokens
+      - name: Accessibility
+      - name: Dark Mode
+  - name: Prototyping
+    timeline: 4 months
+    tags:
+      - name: Phoenix LiveView
+      - name: HTML
+      - name: CSS
+      - name: Browser Prototyping
+testimonial: >-
+  AddnAide is a HIPAA-adjacent home-healthcare workforce platform serving aides,
+  care managers, employers, clients, and admins, covering time entry, review,
+  and agency administration under Electronic Visit Verification and
+  program-compliance rules.
+cite: AddnAide
+icon: "\U0001FA7A"
+color: violet
+tags:
+  - name: Healthcare
+visible: true
+size: featured
+solutions:
+  - title: context-switching role inbox
+    description: >-
+      One person at AddnAide is often a care manager and an employer at once, so
+      the inbox is the home base that holds those roles together. Switching role
+      changes the queue and the actions without moving you to a different part of
+      the app, which keeps people from hunting for the right view before they can
+      start working.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: time entry
+    description: >-
+      Aides log visits from a phone between appointments, so time entry leads
+      with the few details a visit needs and asks for the rest only when the rule
+      requires it. The form carries the Electronic Visit Verification check inline
+      instead of bolting it on at the end, so a clean entry is the fast entry.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: review workflow
+    description: >-
+      Care managers review entries against program rules before time becomes
+      payable. The review screen puts the entry, its compliance status, and the
+      reason for any flag side by side, so a reviewer can approve, correct, or
+      send something back without opening four other pages to understand it.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: admin and role management
+    description: >-
+      Admins decide who can do what across the five roles, so role management
+      shows each person's roles and permissions in plain language rather than a
+      grid of checkboxes. Changing someone's access is one clear action, and the
+      screen tells you what that change lets them do.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: certifications and agreements
+    description: >-
+      Aides have to hold current certifications and signed agreements to stay
+      eligible for visits, so this view tracks both and surfaces what is expiring
+      before it lapses. Tying eligibility to the record keeps an out-of-date aide
+      from being scheduled into work they cannot bill.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: services and operational areas
+    description: >-
+      Agencies deliver specific services inside defined operational areas, and
+      this screen is where that map gets set. Defining services and areas up front
+      means the rest of the app, from scheduling to billing, can reason about what
+      is allowed where instead of asking the user to remember it.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: funders and fiscal management
+    description: >-
+      Visits get paid through programs and funders with their own rules, so the
+      fiscal screens connect the work that happened to the funding that covers it.
+      Keeping funders, rates, and the money in one place gives admins a clear read
+      on what is billable and what is at risk before it reaches a claim.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: 17-section style guide and dark mode
+    description: >-
+      The design system shipped alongside the build as a 17-section style guide:
+      tokens, components, accessibility notes, the architecture decision records
+      behind each choice, and a full dark mode. Dark mode was a real requirement,
+      not a coat of paint, because aides use the app early, late, and in low light,
+      and documenting the decisions kept the build team fast after handoff.
+    media: /assets/images/case-studies/placeholder.svg
+---

--- a/_case-studies/ai-discovery-workflow.md
+++ b/_case-studies/ai-discovery-workflow.md
@@ -1,0 +1,102 @@
+---
+title: AI-Assisted Discovery
+description: >-
+  A discovery workflow that pairs Claude agent personas with code-based
+  prototyping to compress weeks of story-mapping into days, without leaving the
+  method behind.
+problem: >-
+  Discovery is the part that makes the rest of the work right: story mapping,
+  stakeholder interviews, and the synthesis that turns conversations into a plan.
+  It also takes weeks, which is exactly the time small, mighty teams rarely have,
+  so it is the first thing that gets cut and the first thing they miss.
+role: >-
+  I built the workflow. I author the Claude agent personas and pair them with
+  code-based prototyping in Next.js and TypeScript. The personas are grounded in
+  Jeff Patton's user story mapping and jobs-to-be-done, and the methodology stays
+  story-map-first, so the speed comes from the tooling and not from skipping the
+  thinking.
+outcome: >-
+  The workflow compresses weeks of story-mapping discovery into days while keeping
+  the method intact. Each step produces a real artifact a team can use, and the
+  arc runs from a UX audit through personas, a story map, a flow-decision log, a
+  synthesis report, a voice and tone guide, and stakeholder-interview prep.
+cover_image: /assets/images/case-studies/placeholder.svg
+category: product design
+services:
+  - name: Discovery
+    timeline: Ongoing practice
+    tags:
+      - name: User Story Mapping
+      - name: Jobs-to-Be-Done
+      - name: Stakeholder Interviews
+      - name: Synthesis
+  - name: AI Agent Authoring
+    timeline: Ongoing practice
+    tags:
+      - name: Claude Code
+      - name: Agent Personas
+  - name: Prototyping
+    timeline: Ongoing practice
+    tags:
+      - name: Next.js
+      - name: TypeScript
+      - name: Browser Prototyping
+icon: "\U0001F5FA️"
+color: green
+tags:
+  - name: Process
+visible: true
+size: large
+solutions:
+  - title: UX audit
+    description: >-
+      The arc opens with a UX audit of what already exists, so discovery starts
+      from the real product rather than a blank page. An agent persona reads the
+      current screens and flows against known patterns and accessibility
+      standards, then writes up what works, what does not, and what is worth
+      asking users about.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: persona set
+    description: >-
+      Next the workflow drafts a persona set, the people the product is actually
+      for. The agent builds each persona from the jobs they are trying to get done
+      rather than from demographics, which keeps the set honest and gives the
+      story map characters whose goals you can trace through it.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: story map
+    description: >-
+      The story map is the center of the method, and everything else hangs off it.
+      Following Jeff Patton's model, the agent lays out the user's journey as a
+      backbone of activities with the supporting stories underneath, so the team
+      can see the whole and slice a release without losing the narrative.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: flow-decision log
+    description: >-
+      As flows take shape, the workflow keeps a flow-decision log: the choices
+      made, the options weighed, and the reason one won. Writing decisions down as
+      they happen means a team can revisit a flow months later and understand why
+      it is the way it is instead of relitigating it from scratch.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: synthesis report
+    description: >-
+      The synthesis report pulls the audit, personas, and interviews into one read
+      of what the team now knows and what it should do next. The agent does the
+      first pass of finding the patterns across inputs, which is the slow part of
+      synthesis, and hands back something a person can sharpen rather than start.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: voice and tone guide
+    description: >-
+      A voice and tone guide sets how the product talks before a single screen
+      gets written, so the copy reads as one product instead of a dozen authors.
+      The agent drafts the principles and the do-and-do-not examples from the
+      personas and the brand, giving writers and the build team a shared reference.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: stakeholder-interview prep
+    description: >-
+      The last artifact gets a human ready to talk to humans: stakeholder-interview
+      prep with the questions worth asking and the assumptions worth testing. The
+      agent turns the story map and open decisions into a focused script, so the
+      interviews spend their time on what is still unknown rather than on warming
+      up.
+    media: /assets/images/case-studies/placeholder.svg
+---

--- a/_case-studies/configure-2.md
+++ b/_case-studies/configure-2.md
@@ -1,0 +1,127 @@
+---
+title: Configure 2.0
+description: >-
+  The AI-assisted construction-procurement marketplace, designed and shipped as
+  production UI across buyer tools, storefronts, a submittals approval flow, and
+  product recommendations.
+problem: >-
+  A multi-sided procurement marketplace needs a lot to work at once: tools for
+  buyers, storefronts for manufacturers and suppliers, an approval flow for
+  construction submittals, and AI recommendations that hold up against real
+  products. All of it had to ship as production UI, not as comps waiting on a
+  handoff.
+role: >-
+  I was the sole designer. I owned design and shipped production Blazor and Razor
+  across every surface, and I stood up the design system in code, so there was no
+  translation step between Figma and what shipped.
+outcome: >-
+  Shipped Bid Day, the Atlas storefront and discovery platform, the seller
+  pricing tools, Configure Approvals, and Configure Assistant, all on an SCSS
+  token foundation and a domain-specific Blazor component library. The throughline
+  is long: a 2022 HTML and CSS prototype, Auto Submittals Sketch, validated a Cart
+  and Influence a Cart pattern that shipped two years later as the Clipboard-based
+  Configure Approvals.
+cover_image: /assets/images/case-studies/placeholder.svg
+category: product design
+services:
+  - name: Product Design
+    timeline: 2023 to 2025
+    tags:
+      - name: UX Design
+      - name: UI Design
+      - name: Interaction Design
+      - name: Mobile-First Design
+  - name: Design System
+    timeline: 2023 to 2025
+    tags:
+      - name: Design Tokens
+      - name: SCSS
+      - name: Component Library
+  - name: Front-End Development
+    timeline: 2023 to 2025
+    tags:
+      - name: Blazor
+      - name: Razor
+      - name: SignalR
+      - name: Web Accessibility
+testimonial: >-
+  Configure, Inc. builds an AI-assisted construction-procurement marketplace that
+  connects building designers and contractors with manufacturers and suppliers,
+  from quote comparison through submittals approval.
+cite: 'Configure, Inc.'
+icon: "\U0001F3D7️"
+color: orange
+tags:
+  - name: Marketplace
+visible: true
+size: featured
+solutions:
+  - title: Bid Day
+    description: >-
+      Bid Day is where a buyer turns a pile of vendor quotes into a decision. It
+      imports quotes with PDF-to-text conversion so the numbers come in without
+      retyping, lines them up in multi-vendor comparison tables, and lets the
+      buyer export the selections they have chosen. The job is reading offers side
+      by side, so the screen is built around the comparison, not around the files.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: Atlas storefronts and search
+    description: >-
+      Atlas is the multi-sided storefront and discovery platform, with
+      manufacturer and supplier storefronts, browse, and search. A storefront has
+      to read as the brand's own space while still behaving consistently across
+      the marketplace, so the design holds one search and browsing model under
+      pages that each look like their owner.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: product and supplier recommendations
+    description: >-
+      Recommendations sit inside Atlas to point buyers toward products and
+      suppliers that fit what they are specifying. The surface presents a
+      recommendation as something to act on, with the context that earned it
+      visible, rather than as a black-box list, so a buyer can trust it enough to
+      move it into a quote.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: networking and real-time activity
+    description: >-
+      Atlas added professional networking on top of the marketplace: user search,
+      add-to-network with organization affiliations, and an activity feed. A
+      platform-wide notifications layer driven by SignalR keeps it live, and
+      CometChat is embedded for chat with the shell designed around it, so the
+      social surfaces feel like part of the product instead of bolted-on widgets.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: Configure Approvals
+    description: >-
+      Approvals is a construction-submittals workflow built around code-shareable
+      Clipboards. A stakeholder builds a Clipboard, shares it by short code,
+      suggests swaps, and sends it to order, with status indicators marking items
+      approved, edited, or swapped. Presentation-mode product cards make it
+      reviewable on a client's phone, so approval happens where the client already
+      is.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: from Auto Submittals Sketch to Clipboards
+    description: >-
+      In 2022 I built Auto Submittals Sketch, an HTML and CSS prototype, to test a
+      Cart and Influence a Cart pattern for asymmetric collaboration, where one
+      side proposes and another approves. The prototype earned a spot on the
+      roadmap and shipped two years later as the Clipboard model inside Configure
+      Approvals. The interaction was proven in the browser long before it became
+      the product.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: Configure Assistant
+    description: >-
+      Assistant is the platform's AI product-recommendation chat: natural-language
+      product search, thumbs-up and thumbs-down feedback, and a create-recommendation
+      flow that turns a conversation into a quote or promotion. I partnered with the
+      AI team on the knowledge-graph backend built on ontoGPT and OpenAI
+      function-calling, and designed the chat so the model's answers become real
+      actions a buyer can take.
+    media: /assets/images/case-studies/placeholder.svg
+  - title: the design system in code
+    description: >-
+      The design system shipped as code, not as a separate artifact: an SCSS token
+      foundation for color, type, spacing, layout, and utilities, and a
+      domain-specific Blazor component library. Alongside Cards, Modals, and Tables,
+      it carried purpose-built pieces, RiskMeter, FileDropZone, ComparisonTable,
+      SubmittalImportForm, ChecklistItem, and DocumentViewerModal, used across every
+      shipped surface with no Figma-to-production handoff.
+    media: /assets/images/case-studies/placeholder.svg
+---

--- a/assets/images/case-studies/placeholder.svg
+++ b/assets/images/case-studies/placeholder.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="900" viewBox="0 0 1200 900" role="img" aria-label="Screenshot coming soon">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6b4eff"/>
+      <stop offset="1" stop-color="#5a3ff0"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="900" fill="#f4f2ff"/>
+  <rect x="48" y="48" width="1104" height="804" rx="32" fill="url(#bg)"/>
+  <rect x="48" y="48" width="1104" height="804" rx="32" fill="none" stroke="#ffffff" stroke-opacity="0.18" stroke-width="2"/>
+  <g fill="#ffffff" fill-opacity="0.9">
+    <rect x="528" y="360" width="144" height="108" rx="14" fill="none" stroke="#ffffff" stroke-opacity="0.85" stroke-width="6"/>
+    <circle cx="566" cy="398" r="14"/>
+    <path d="M540 462 L588 416 L624 452 L654 426 L660 462 Z"/>
+  </g>
+  <text x="600" y="560" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="44" font-weight="600" fill="#ffffff">Screenshot coming soon</text>
+</svg>


### PR DESCRIPTION
Final PR in the content & messaging refresh. Adds Ryan's strongest, most recent, most senior work, which was entirely absent from the site. Stacked onto `release/content-refresh`.

## What this does
Three new case studies, fully written in the project voice, using the same Problem → My role → Solution → Outcome structure as the restructure PR:

- **AddnAide** — HIPAA-adjacent home-healthcare workforce platform; sole designer; full-fidelity Phoenix LiveView prototypes; a 17-section design system. (`featured`, 8 screens)
- **Configure 2.0** — sole designer on the AI-assisted construction-procurement marketplace (Bid Day, Atlas, Configure Approvals, Configure Assistant); shipped production Blazor/Razor with no Figma-to-production handoff. (`featured`, 8 screens)
- **AI-Assisted Discovery** — Ryan's own workflow pairing Claude agent personas with code-based Next.js prototyping, compressing weeks of discovery into days. (`large`, 7 artifacts)

No invented metrics — every claim traces to the resume / enhanced descriptions.

## ⚠️ Action needed before merging this PR
Each study uses a shared placeholder image (`assets/images/case-studies/placeholder.svg`) for now. **Add real screenshots, then merge.** Drop PNGs into `assets/images/case-studies/` and replace the `placeholder.svg` references (each study's `cover_image` plus every `solutions[].media`). Suggested filenames:

**AddnAide** (`_case-studies/addnaide.md`): `addnaide-thumbnail`, `addnaide-role-inbox`, `addnaide-time-entry`, `addnaide-review-workflow`, `addnaide-admin-role-management`, `addnaide-certifications-agreements`, `addnaide-services-operational-areas`, `addnaide-funders-fiscal`, `addnaide-style-guide-dark-mode`

**Configure 2.0** (`_case-studies/configure-2.md`): `configure-2-thumbnail`, `configure-2-bid-day`, `configure-2-atlas-storefronts`, `configure-2-recommendations`, `configure-2-networking-activity`, `configure-2-approvals`, `configure-2-auto-submittals-sketch`, `configure-2-assistant`, `configure-2-design-system`

**AI-Assisted Discovery** (`_case-studies/ai-discovery-workflow.md`): `ai-discovery-thumbnail`, `ai-discovery-ux-audit`, `ai-discovery-personas`, `ai-discovery-story-map`, `ai-discovery-flow-decision-log`, `ai-discovery-synthesis-report`, `ai-discovery-voice-tone-guide`, `ai-discovery-interview-prep`

Until real images are in, these three studies show the "Screenshot coming soon" placeholder. They're `visible: true`, so they'll appear in the grid the moment this PR merges — add images first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)